### PR TITLE
13 eventual header missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to ScEntra will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-12-10
+
+### Fixed
+- Missing `ConsistencyLevel: eventual` header for Microsoft Graph API count queries
+- Updated module version to 1.0.2
+
 ## [1.0.1] - 2025-12-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2] - 2025-12-10
 
 ### Fixed
-- Missing `ConsistencyLevel: eventual` header for Microsoft Graph API count queries
-- Updated module version to 1.0.2
+- Missing `ConsistencyLevel: eventual` header in batch processing functions (`Invoke-GraphBatchRequest`)
+- Graph API `/$count` queries now work correctly for both sequential and parallel batch processing paths
+- Environment size determination (Step 1/5 of analysis) no longer fails with "Request_UnsupportedQuery" error
+- Users installing from repository on December 10th or later will have this fix included
 
 ## [1.0.1] - 2025-12-15
 

--- a/Private/GraphHelpers.ps1
+++ b/Private/GraphHelpers.ps1
@@ -277,12 +277,8 @@ function Invoke-GraphRequest {
     $headers = @{
         'Authorization'    = "Bearer $script:GraphAccessToken"
         'Content-Type'     = 'application/json'
+        'ConsistencyLevel' = 'eventual'
         'User-Agent'       = "ScEntra/$moduleVersion (PowerShell/$($PSVersionTable.PSVersion))"
-    }
-
-    # Add ConsistencyLevel header for advanced queries like $count
-    if ($Uri -like '*$count') {
-        $headers['ConsistencyLevel'] = 'eventual'
     }
 
     $params = @{

--- a/Private/GraphHelpers.ps1
+++ b/Private/GraphHelpers.ps1
@@ -573,8 +573,9 @@ function Invoke-GraphBatchRequest {
 
             try {
                 $headers = @{
-                    'Authorization' = "Bearer $graphAccessToken"
-                    'Content-Type'  = 'application/json'
+                    'Authorization'    = "Bearer $graphAccessToken"
+                    'Content-Type'     = 'application/json'
+                    'ConsistencyLevel' = 'eventual'
                 }
 
                 $batchUri = "$graphBaseUrl/`$batch"
@@ -619,8 +620,9 @@ function Invoke-GraphBatchRequest {
 
             try {
                 $headers = @{
-                    'Authorization' = "Bearer $using:graphAccessToken"
-                    'Content-Type'  = 'application/json'
+                    'Authorization'    = "Bearer $using:graphAccessToken"
+                    'Content-Type'     = 'application/json'
+                    'ConsistencyLevel' = 'eventual'
                 }
 
                 $batchUri = "$using:graphBaseUrl/`$batch"

--- a/Private/GraphHelpers.ps1
+++ b/Private/GraphHelpers.ps1
@@ -264,7 +264,7 @@ function Invoke-GraphRequest {
     }
 
     # Get module version for User-Agent
-    $moduleVersion = '1.0.0'
+    $moduleVersion = '1.0.2'
     try {
         $module = Get-Module -Name ScEntra -ErrorAction SilentlyContinue
         if ($module) {
@@ -277,8 +277,12 @@ function Invoke-GraphRequest {
     $headers = @{
         'Authorization'    = "Bearer $script:GraphAccessToken"
         'Content-Type'     = 'application/json'
-        'ConsistencyLevel' = 'eventual'
         'User-Agent'       = "ScEntra/$moduleVersion (PowerShell/$($PSVersionTable.PSVersion))"
+    }
+
+    # Add ConsistencyLevel header for advanced queries like $count
+    if ($Uri -like '*`$count*') {
+        $headers['ConsistencyLevel'] = 'eventual'
     }
 
     $params = @{

--- a/Private/GraphHelpers.ps1
+++ b/Private/GraphHelpers.ps1
@@ -281,7 +281,7 @@ function Invoke-GraphRequest {
     }
 
     # Add ConsistencyLevel header for advanced queries like $count
-    if ($Uri -like '*`$count*') {
+    if ($Uri -like '*$count') {
         $headers['ConsistencyLevel'] = 'eventual'
     }
 

--- a/ScEntra.psd1
+++ b/ScEntra.psd1
@@ -3,7 +3,7 @@
     RootModule = 'ScEntra.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.1'
+    ModuleVersion = '1.0.2'
 
     # ID used to uniquely identify this module
     GUID = '8c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f'


### PR DESCRIPTION
This pull request updates the ScEntra module to version 1.0.2 and addresses a missing header in Microsoft Graph API count queries. The most important changes are:

Bug fixes and improvements:

* Added the missing `ConsistencyLevel: eventual` header for Microsoft Graph API count queries to ensure accurate results.

Version updates:

* Updated the module version to `1.0.2` in `ScEntra.psd1` and `GraphHelpers.ps1` to reflect the new release. [[1]](diffhunk://#diff-0a14f613af15ab01518da014e5d92d6cc82d3155e0daedec6941eabb791f834aL6-R6) [[2]](diffhunk://#diff-1704baa545b3e0547a2b46fbfe49e4cd66fd71b25590a5ca11dbee4833906069L267-R267)
* Documented the changes for version 1.0.2 in the `CHANGELOG.md`.

closes #13 