### PR TITLE
Fix README to use -ClientSecret parameter instead of non-existent -Cr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inconsistent function references in service principal documentation
 - Redaction of group names in escalation risk descriptions
 - Documentation examples that referenced non-existent function parameters
+- Corrected README.md to use `-ClientSecret` parameter instead of non-existent `-Credential` parameter
 
 ### Security
 - Added comprehensive security best practices documentation

--- a/README.md
+++ b/README.md
@@ -106,9 +106,7 @@ $sp | Format-List
 # Click: "Grant admin consent for [Your Tenant]"
 
 # Use the service principal
-$clientSecret = ConvertTo-SecureString -String '<client_secret>' -AsPlainText -Force
-$credential = New-Object PSCredential('<application_id>', $clientSecret)
-Connect-ScEntraGraph -TenantId '<tenant_id>' -Credential $credential
+Connect-ScEntraGraph -TenantId '<tenant_id>' -ClientId '<application_id>' -ClientSecret '<client_secret>'
 ```
 
 📖 **For detailed setup instructions, certificate authentication, and security best practices**, see:  


### PR DESCRIPTION
closes #12 

Documentation corrections:

* Updated the authentication example in `README.md` to use the `-ClientSecret` parameter instead of the non-existent `-Credential` parameter, aligning the documentation with the actual supported parameters.
* Noted in `CHANGELOG.md` that the `README.md` now correctly references the `-ClientSecret` parameter for service principal authentication.